### PR TITLE
Fixed typographical error, changed Carribbean to Caribbean in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Bolded songs are potential chopping block candidates.
 * Hall & Oates - You Make My Drums
 * Eddie Money - Think I’m In Love
 * Michael Jackson - P.Y.T.
-* Billy Ocean - Carribbean Queen (No More Love on the Run)
+* Billy Ocean - Caribbean Queen (No More Love on the Run)
 * Philip Bailey & Phil Collins - Easy Lover
 * Lionel Richie - Dancing On The Ceiling
 * Chaka Khan - Ain’t Nobody


### PR DESCRIPTION
mlettini, I've corrected a typographical error in the documentation of the [Best-Playlist-Ever](https://github.com/mlettini/Best-Playlist-Ever) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
